### PR TITLE
Deployment

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-baseURL: https://varunpatel.ca/
+baseURL: /
 languageCode: en
 title: "Varun Patel"
 theme: "toha"


### PR DESCRIPTION
update toha to latest version (v3.4.0)
changed baseurl to be deployment agnostic (now deploying previews to cloudflare pages)